### PR TITLE
Use pathlib for platform independence when managing paths

### DIFF
--- a/birdsongs/paths.py
+++ b/birdsongs/paths.py
@@ -1,18 +1,19 @@
-import os, glob
+import os
 import pandas as pd
+from pathlib import Path
 
 class Paths(object):
     def __init__(self, root_path=None, audios_path=None, bird_name=None):
-        if root_path==None: self.root = ".\\examples\\"
-        else:               self.root = root_path
+        if root_path==None: self.root = Path("./examples")
+        else:               self.root = Path(root_path)
         #self.base     = "{}birdsongs\\".format(self.root) 
-        self.auxdata  = '{}auxiliar_data\\'.format(self.root)
-        self.results  = '{}results\\'.format(self.root) 
-        self.examples = '{}audios\\'.format(self.results)  # write audios folder
+        self.auxdata  = self.root / 'auxiliar_data'
+        self.results  = self.root / 'results'
+        self.examples = self.results / 'audios'  # write audios folder
         
         if audios_path==None:
-            self.audios      = '{}audios\\'.format(self.root)     # wav folder
-            self.sound_files = glob.glob(os.path.join(self.audios, '*wav'))
+            self.audios      = self.root / 'audios'     # wav folder
+            self.sound_files = list(self.audios.glob("*.wav"))
         else:
             if "ebird" in audios_path: 
                 search_by, name_col = "Scientific Name", "ML Catalog Number"
@@ -38,10 +39,10 @@ class Paths(object):
             else: self.sound_files = []
         
         self.no_files    = len(self.sound_files)
-        self.files_names = [self.sound_files[i][len(self.audios):] for i in range(self.no_files)]
+        self.files_names = [f.name for f in self.sound_files]
         
-        if not os.path.exists(self.results):    os.makedirs(self.results)
-        if not os.path.exists(self.examples):   os.makedirs(self.examples)
+        self.results.mkdir(parents=True, exist_ok=True)
+        self.examples.mkdir(parents=True, exist_ok=True)
         print("The folder has {} songs".format(self.no_files))
         
     def ShowFiles(self):

--- a/birdsongs/plots.py
+++ b/birdsongs/plots.py
@@ -143,10 +143,10 @@ class Ploter(object):
                 
                 ax[0].legend(loc='upper right', title="FF")
 
-                path_save = obj.paths.results+"AllSongAndSyllable-{}-{}.png".format(obj.no_file,obj.no_syllable)
-            else: path_save = obj.paths.results+"AllSongAndSyllable-{}.png".format(obj.no_file)
+                path_save = obj.paths.results / "AllSongAndSyllable-{}-{}.png".format(obj.no_file,obj.no_syllable)
+            else: path_save = obj.paths.results / "AllSongAndSyllable-{}.png".format(obj.no_file)
 
-            fig.suptitle('Audio: {}'.format(obj.file_name[39:]), fontsize=18)
+            fig.suptitle('Audio: {}'.format(obj.file_name.name), fontsize=18)
             plt.show()
             return fig, ax
         


### PR DESCRIPTION
Hi there!

I was searching around for usages of mpl-interactions in order to update something with `zoom_factory` and `panmanager` (PR in coming) and I found this project. Looks very cool! But when I went to try it out on my linux computer I found that the paths brokes as they assume windows naming conventions. So this PR changes the file path handling to us the builtin Pathlib module which makes it easy to support all platforms with the same code.